### PR TITLE
Remove references to activator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ $ sbt run
 
 Now you are ready to point your browser to [http://localhost:9000](http://localhost:9000).
 The only prerequisites are [SBT](http://www.scala-sbt.org/download.html) and [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
-Sangria playground is also available as a [Typesafe Activator Template](https://www.typesafe.com/activator/template/sangria-playground).

--- a/activator.properties
+++ b/activator.properties
@@ -1,4 +1,0 @@
-name=sangria-playground
-title=Sangria Playground
-description=An example of GraphQL server written with Play and Sangria.
-tags=sangria,graphql,playframework,scala,basics


### PR DESCRIPTION
`activator` is being killed 10 days from now: https://www.lightbend.com/blog/introducing-a-new-way-to-get-started-with-lightbend-technologies-and-saying-goodbye-to-activator