### PR TITLE
when one of the arguments of the query is of the wrong type, the error should be correctly displayed.

### DIFF
--- a/public/javascripts/app.js
+++ b/public/javascripts/app.js
@@ -108,7 +108,10 @@ $(function() {
     })
     .fail(function (error) {
       if (error.status === 400 && error.responseJSON && error.responseJSON.syntaxError)
-      $("#responseError").html($("<pre>").html(error.responseJSON.syntaxError))
+        $("#responseError").html($("<pre>").html(error.responseJSON.syntaxError))
+
+      if (error.status === 400 && error.responseJSON && error.responseJSON.errors)
+        $("#responseError").html($("<pre>").html(error.responseJSON.errors[0].message))
 
       $("#response").collapse('hide')
       $("#errors").collapse('show')


### PR DESCRIPTION
When I tried this query:

```
query HeroAndFriends {
  droid(id: 2000) {
    name
    friends {
      name
    }
  }
}
```
(note that the query is wrong since id should be a string)

I had an error which was not correctly displayed:

```
Argument 'id' expected type 'String!' but got: 2000. Reason: String value expected (line 2, column 13):
  droid(id: 2000) {
```
so I changed the js code to display it correctly.
