### PR TITLE
Swapped broken url with github page url closes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 This is an example of a [GraphQL](https://facebook.github.io/graphql) server written with [Play framework](https://www.playframework.com) and
-[Sangria](http://sangria-graphql.org).
+[Sangria](https://github.com/sangria-graphql/sangria).
 
 If you'd like to explore a GraphQL server built with Sangria you may do so here: [Sangria Playground](https://sangria-play-example.herokuapp.com). On the right hand side you can see a textual representation of the GraphQL
 schema which is implemented on the server and that you can query here. On the left hand side


### PR DESCRIPTION
Problem is explained in issue #24. Swapped the non-owned url to the url leading to the sangria github repo.